### PR TITLE
[#1] fix status display issue

### DIFF
--- a/classes/category_status_table.php
+++ b/classes/category_status_table.php
@@ -103,11 +103,7 @@ class category_status_table extends table_sql {
      */
     public function col_status(object $row) {
         $clonedestination = $this->get_row_corresponding_clone_course($row->shortname);
-
-        // Does the clone destination course exist? If yes report success.
-        if (!empty($clonedestination->course)) {
-            return \html_writer::tag('p', get_string('success', 'tool_clonecategory'), ['class' => 'badge badge-success']);
-        }
+        // Note - check for tasks first, since the course might exist but the contents inside are still being backed up.
 
         // Is there an adhoc task for the clone source course?
         // If so output either started or inprogress depending on adhoc task status.
@@ -126,6 +122,11 @@ class category_status_table extends table_sql {
             $delta = format_time(time() - $task->get_timestarted());
             return \html_writer::tag('p', get_string('started', 'tool_clonecategory', $delta), ['class' => 'badge badge-info',
                 'title' => $timestamp]);;
+        }
+
+        // Does the clone destination course exist? If yes report success.
+        if (!empty($clonedestination->course)) {
+            return \html_writer::tag('p', get_string('success', 'tool_clonecategory'), ['class' => 'badge badge-success']);
         }
 
         // Else is unknown.

--- a/version.php
+++ b/version.php
@@ -25,6 +25,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_clonecategory';
 $plugin->version = 2023061300;
+$plugin->release = 2023061300;
 $plugin->requires = 2014051200;
-$plugin->maturity = MATURITY_RC;
-$plugin->release = 'v1.0.rc1';
+$plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_clonecategory';
-$plugin->version = 2023052600;
+$plugin->version = 2023061300;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_RC;
 $plugin->release = 'v1.0.rc1';


### PR DESCRIPTION
Closes #1 

### Issue 
I'm not sure why the backup API does this, but this comes from the fact that course shortnames behave strangely when backing up / restoring.

When backing up / restoring the following would happen:

- Task starts and no course yet -> table shows `In progress`
- `mdl_course` record is created, but restore is still in progress. Course is created initially with the correct shortname -> table shows `Complete` (since course with correct shortname exists)
- Course shortname changes to the old course shortname as backup progresses -> Table shows `In progress` (since course with shortname no longer exists)
- Course backup complete, task is done, course shortname is changed to correct one, -> course exists with shortname,  table shows `Complete`

I was able to confirm this was happening by spamming refresh on adminer while the tasks were running and was able to observe the shortnames changing (its about 1 second before they change back again)
 
### Fix
The easiest fix is just to check if there is a task there first, it should be in progress regardless of whether there is a course there or not. 

Only when there are no tasks should we check for the existence of the course.
