### PR TITLE
#5 add functionality to limit history table by date

### DIFF
--- a/classes/form/clonecategoryhistory_form.php
+++ b/classes/form/clonecategoryhistory_form.php
@@ -36,34 +36,10 @@ class clonecategoryhistory_form extends \moodleform {
         $data = $this->_customdata;
         $buttonlabel = get_string('clone_history', 'tool_clonecategory');
 
-        // Timestamp of start date of all newly cloned courses.
-        $mform->addElement('date_selector', 'startdate', get_string('historystartdate', 'tool_clonecategory'));
-        $mform->setDefault('startdate', $data['startdate']);
-
-        // Timestamp of end date of all newly cloned courses.
-        $mform->addElement('date_selector', 'enddate', get_string('historyenddate', 'tool_clonecategory'));
-        $mform->setDefault('enddate', $data['enddate']);
+        $mform->addElement('duration', 'timelimit', get_string('historylimit', 'tool_clonecategory'), array('defaultunit' => DAYSECS));
+        $mform->setDefault('timelimit', $data['timelimit']);
 
         $this->add_action_buttons(true, $buttonlabel);
-    }
-
-    /**
-     * Validates the data submit for this form.
-     *
-     * @param array $data An array of key,value data pairs.
-     * @param array $files Any files that may have been submit as well.
-     * @return array An array of errors.
-     */
-    public function validation($data, $files) {
-        global $DB;
-        $errors = parent::validation($data, $files);
-
-        if (!empty($data['enddate']) && !empty($data['startdate'])) {
-            if ($data['enddate'] < $data['startdate'] || $data['startdate'] === $data['enddate']) {
-                $errors['enddate'] = get_string('error_date_problem', 'tool_clonecategory');
-            }
-        }
-        return $errors;
     }
 
     /**

--- a/classes/form/clonecategoryhistory_form.php
+++ b/classes/form/clonecategoryhistory_form.php
@@ -1,0 +1,75 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_clonecategory\form;
+
+defined('MOODLE_INTERNAL') || die;
+require_once($CFG->libdir.'/formslib.php');
+
+/**
+ * Clone category history form.
+ *
+ * @package tool_clonecategory
+ * @copyright 2018 tim@avide.com.au
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class clonecategoryhistory_form extends \moodleform {
+
+    /**
+     * The form definition.
+     */
+    public function definition() {
+        $mform = $this->_form;
+        $data = $this->_customdata;
+        $buttonlabel = get_string('clone_history', 'tool_clonecategory');
+
+        // Timestamp of start date of all newly cloned courses.
+        $mform->addElement('date_selector', 'startdate', get_string('historystartdate', 'tool_clonecategory'));
+        $mform->setDefault('startdate', $data['startdate']);
+
+        // Timestamp of end date of all newly cloned courses.
+        $mform->addElement('date_selector', 'enddate', get_string('historyenddate', 'tool_clonecategory'));
+        $mform->setDefault('enddate', $data['enddate']);
+
+        $this->add_action_buttons(true, $buttonlabel);
+    }
+
+    /**
+     * Validates the data submit for this form.
+     *
+     * @param array $data An array of key,value data pairs.
+     * @param array $files Any files that may have been submit as well.
+     * @return array An array of errors.
+     */
+    public function validation($data, $files) {
+        global $DB;
+        $errors = parent::validation($data, $files);
+
+        if (!empty($data['enddate']) && !empty($data['startdate'])) {
+            if ($data['enddate'] < $data['startdate'] || $data['startdate'] === $data['enddate']) {
+                $errors['enddate'] = get_string('error_date_problem', 'tool_clonecategory');
+            }
+        }
+        return $errors;
+    }
+
+    /**
+     * Resets the form.
+     */
+    public function reset() {
+        $this->_form->updateSubmission(null, null);
+    }
+}

--- a/classes/history_table.php
+++ b/classes/history_table.php
@@ -32,10 +32,9 @@ class history_table extends table_sql {
      /**
       * Create table
       * @param string $uniqueid
-      * @param int $startdate
-      * @param int $enddate
+      * @param int $timelimit
       */
-    public function __construct(string $uniqueid, int $startdate, int $enddate) {
+    public function __construct(string $uniqueid, int $timelimit) {
         global $PAGE, $DB;
 
         parent::__construct($uniqueid);
@@ -56,8 +55,7 @@ class history_table extends table_sql {
         $this->define_headers($headers);
         $this->baseurl = $PAGE->url;
         $this->sortable(false, 'timecreated', SORT_DESC);
-        $this->startdate = $startdate;
-        $this->enddate = $enddate;
+        $this->timelimit = $timelimit;
     }
 
     /**
@@ -97,11 +95,10 @@ class history_table extends table_sql {
 
     /**
      * Creates table and renders it.
-     * @param int $startdate
-     * @param int $enddate
+     * @param int $timelimit
      */
-    public static function display(int $startdate = 0, int $enddate = 0) {
-        $table = new history_table(uniqid('queued_table'), $startdate, $enddate);
+    public static function display(int $timelimit) {
+        $table = new history_table(uniqid('queued_table'), $timelimit);
         $table->set_attribute('class', 'generalbox generaltable table-sm');
         $table->out(100, true);
     }
@@ -117,12 +114,12 @@ class history_table extends table_sql {
         $manager = get_log_manager();
         $readers = $manager->get_readers();
         $reader = reset($readers);
+        $starttime = time() - $this->timelimit;
 
         // Grab recordset for course_cloned event.
         $event = '\tool_clonecategory\event\course_cloned';
-        $select = "eventname = ? AND timecreated > ? AND timecreated < ?";
+        $select = "eventname = ? AND timecreated > ?";
 
-        $this->rawdata = $reader->get_events_select($select, array($event, $this->startdate, $this->enddate), '', null, null);
-
+        $this->rawdata = $reader->get_events_select($select, array($event, $starttime), '', null, null);
     }
 }

--- a/classes/history_table.php
+++ b/classes/history_table.php
@@ -32,8 +32,10 @@ class history_table extends table_sql {
      /**
       * Create table
       * @param string $uniqueid
+      * @param int $startdate
+      * @param int $enddate
       */
-    public function __construct(string $uniqueid) {
+    public function __construct(string $uniqueid, int $startdate = 0, int $enddate = 0) {
         global $PAGE, $DB;
 
         parent::__construct($uniqueid);
@@ -56,8 +58,15 @@ class history_table extends table_sql {
         $this->define_headers($headers);
         $this->baseurl = $PAGE->url;
 
-        $this->set_sql('id,other,timecreated', '{logstore_standard_log}', "eventname = :eventname",
-            ['eventname' => '\tool_clonecategory\event\course_cloned']);
+        $this->set_sql('id,other,timecreated',
+            '{logstore_standard_log}',
+            "eventname = :eventname AND timecreated > :startdate AND timecreated < :enddate",
+            [
+                'eventname' => '\tool_clonecategory\event\course_cloned',
+                'startdate' => $startdate,
+                'enddate' => $enddate,
+            ]
+        );
         $this->sortable(false, 'timecreated', SORT_DESC);
     }
 
@@ -100,9 +109,11 @@ class history_table extends table_sql {
 
     /**
      * Creates table and renders it.
+      * @param int $startdate
+      * @param int $enddate
      */
-    public static function display() {
-        $table = new history_table(uniqid('queued_table'));
+    public static function display(int $startdate = 0, int $enddate = 0) {
+        $table = new history_table(uniqid('queued_table'), $startdate, $enddate);
         $table->set_attribute('class', 'generalbox generaltable table-sm');
         $table->out(100, true);
     }

--- a/history.php
+++ b/history.php
@@ -21,6 +21,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use tool_clonecategory\form\clonecategoryhistory_form;
 use tool_clonecategory\history_table;
 
 require('../../../config.php');
@@ -28,10 +29,28 @@ require_once($CFG->libdir . '/adminlib.php');
 
 admin_externalpage_setup('clonecategory_history');
 
+$start = optional_param('start', strtotime('-3 month', time()), PARAM_INT);
+$end = optional_param('end', time(), PARAM_INT);
+
+$clonehistoryform = new clonecategoryhistory_form(null, [
+   'startdate' => $start,
+   'enddate' => $end,
+]);
+
+// Redirect back if form is cancelled.
+if ($clonehistoryform->is_cancelled()) {
+    redirect(new moodle_url("/admin/tool/clonecategory/history.php"));
+}
+
 $PAGE->set_url(new moodle_url("/admin/tool/clonecategory/history.php"));
 $PAGE->set_context(context_system::instance());
 
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('history_table', 'tool_clonecategory'));
-history_table::display();
+
+if ($data = $clonehistoryform->get_data()) {
+    history_table::display($data->startdate, $data->enddate);
+}
+$clonehistoryform->display();
+
 echo $OUTPUT->footer();

--- a/history.php
+++ b/history.php
@@ -27,30 +27,32 @@ use tool_clonecategory\history_table;
 require('../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 
+\core\session\manager::write_close();
+
 admin_externalpage_setup('clonecategory_history');
 
-$start = optional_param('start', strtotime('-3 month', time()), PARAM_INT);
-$end = optional_param('end', time(), PARAM_INT);
+// Default timelimit 31 days.
+$timelimit = optional_param_array('timelimit', 2678400, PARAM_INT);
 
 $clonehistoryform = new clonecategoryhistory_form(null, [
-   'startdate' => $start,
-   'enddate' => $end,
+   'timelimit' => $timelimit,
 ]);
-
-// Redirect back if form is cancelled.
-if ($clonehistoryform->is_cancelled()) {
-    redirect(new moodle_url("/admin/tool/clonecategory/history.php"));
-}
 
 $PAGE->set_url(new moodle_url("/admin/tool/clonecategory/history.php"));
 $PAGE->set_context(context_system::instance());
 
+// Redirect back if form is cancelled.
+if ($clonehistoryform->is_cancelled()) {
+    redirect($PAGE->url);
+}
+
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('history_table', 'tool_clonecategory'));
 
-if ($data = $clonehistoryform->get_data()) {
-    history_table::display($data->startdate, $data->enddate);
-}
 $clonehistoryform->display();
+
+if ($data = $clonehistoryform->get_data()) {
+    history_table::display($data->timelimit);
+}
 
 echo $OUTPUT->footer();

--- a/lang/en/tool_clonecategory.php
+++ b/lang/en/tool_clonecategory.php
@@ -76,5 +76,4 @@ $string['success'] = 'Success';
 $string['error:invalididnumber'] = 'The ID number of the category given to create is already linked to a category that is not a child of the destination category selected';
 
 $string['clone_history'] = 'View clone logs';
-$string['historystartdate'] = 'Start date';
-$string['historyenddate'] = 'End date';
+$string['historylimit'] = 'Limit logs to previous';

--- a/lang/en/tool_clonecategory.php
+++ b/lang/en/tool_clonecategory.php
@@ -74,3 +74,7 @@ $string['failed'] = 'Failed';
 $string['success'] = 'Success';
 
 $string['error:invalididnumber'] = 'The ID number of the category given to create is already linked to a category that is not a child of the destination category selected';
+
+$string['clone_history'] = 'View clone logs';
+$string['historystartdate'] = 'Start date';
+$string['historyenddate'] = 'End date';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_clonecategory';
-$plugin->version = 2023061300;
+$plugin->version = 2023080700;
 $plugin->release = 2023061300;
 $plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Closes #5 

### Issue

With large log files, history can take a long time until display. One example took 11 minutes.

### Fix

Limiting the query to a specified date range significantly reduces time to display.

Added 2 Date fields pre filled with today's date and 3 months previous.

User can select date range for history to be displayed.