### PR TITLE
WR-424432: Add null privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,45 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for tool_clonecategory.
+ *
+ * @package    tool_clonecategory
+ * @copyright  2023 Djarran Cotleanu
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_clonecategory\privacy;
+
+/**
+ * Privacy Subsystem for tool_clonecategory implementing null_provider.
+ *
+ * @copyright  2023 Djarran Cotleanu
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}
+

--- a/lang/en/tool_clonecategory.php
+++ b/lang/en/tool_clonecategory.php
@@ -77,3 +77,6 @@ $string['error:invalididnumber'] = 'The ID number of the category given to creat
 
 $string['clone_history'] = 'View clone logs';
 $string['historylimit'] = 'Limit logs to previous';
+
+$string['privacy:metadata'] = 'The clone category plugin does not store any personal data.';
+


### PR DESCRIPTION
The following error within the pipeline occurred due to an unimplemented privacy provider for this plugin:
```
3) core_privacy\privacy\provider_test::test_all_providers_compliant with data set "tool_clonecategory" ('tool_clonecategory', 'tool_clonecategory\privacy\provider')
Failed asserting that false is true.
```

Going through the code for this plugin, no information about a user's personal data is saved to a database, therefore a null privacy provider was added. 